### PR TITLE
fix #49

### DIFF
--- a/src/components/common/input.jsx
+++ b/src/components/common/input.jsx
@@ -13,6 +13,7 @@ const Input = ({ name, label, error, type, ...rest }) => {
           </label>
           <input
             {...rest}
+            type={type}
             id={name}
             name={name}
             className={type === "chat" ? "chat-input" : "form-control"}


### PR DESCRIPTION
Solve #49. `type` was not used in the DOM. React knew it was a password type but the browser did not.