### PR TITLE
Remove dashed layouts around divs at selection, darken the background instead.

### DIFF
--- a/src/components/layout/browseServers/browseServers.css
+++ b/src/components/layout/browseServers/browseServers.css
@@ -65,4 +65,5 @@
 .browse-robot-server-container:active {
   background-color: rgb(32, 32, 58);
   cursor: pointer;
+  outline: dashed;
 }

--- a/src/components/layout/browseServers/browseServers.css
+++ b/src/components/layout/browseServers/browseServers.css
@@ -1,3 +1,7 @@
+*:focus {
+    outline: none;
+}
+
 .browse-servers-container {
   background-color: rgb(25, 25, 36);
   padding: 24px;
@@ -55,5 +59,10 @@
 
 .browse-robot-server-container:hover {
   background-color: rgb(42, 42, 68);
+  cursor: pointer;
+}
+
+.browse-robot-server-container:active {
+  background-color: rgb(32, 32, 58);
   cursor: pointer;
 }

--- a/src/components/layout/robotServer/robotServer.css
+++ b/src/components/layout/robotServer/robotServer.css
@@ -92,6 +92,12 @@ a:active {
   cursor: pointer;
 }
 
+.display-robot-server-container:active {
+  background-color: rgb(64, 64, 85);
+
+  cursor: pointer;
+}
+
 .selected-server {
   /* border-left: 6px solid cyan; */
   box-shadow: inset 6px 0 0 0 cyan; /* Border left */


### PR DESCRIPTION
When clicking:

Before:
![image](https://user-images.githubusercontent.com/11392207/62401279-cced7200-b582-11e9-8908-5b09c021df9c.png)

After:
![image](https://user-images.githubusercontent.com/11392207/62401222-8ac43080-b582-11e9-865f-13e536af9cb2.png)

Similar (without the dashes) for the left nav.

Possibly related to https://github.com/jillytot/remote-control/issues/151
